### PR TITLE
Specify home directory for camfort fixtures

### DIFF
--- a/modules/dtg/manifests/jenkins.pp
+++ b/modules/dtg/manifests/jenkins.pp
@@ -29,12 +29,12 @@ class dtg::jenkins {
   # Invoking Haskell package manager to install CamFort dependencies
   ->
   exec {'update-cabal':
-    command => '/usr/bin/cabal update',
+    command => 'HOME=/root /usr/bin/cabal update',
   } ->
   exec {'install-cabal-packages':
     # Check if the dependencies are already installed
-    unless  => '/usr/bin/ghc-pkg list | /bin/sed -ze "s/\n//g" | /bin/grep -o fclabels.*generic-deriving.*language-fortran.*matrix.*syz.*uniplate > /dev/null',
-    command => '/usr/bin/cabal install syz generic-deriving uniplate matrix fclabels language-fortran',
+    unless  => 'HOME=/root /usr/bin/ghc-pkg list | /bin/sed -ze "s/\n//g" | /bin/grep -o fclabels.*generic-deriving.*language-fortran.*matrix.*syz.*uniplate > /dev/null',
+    command => 'HOME=/root /usr/bin/cabal install syz generic-deriving uniplate matrix fclabels language-fortran',
   }
   #packages required by jenkins
   package {['jenkins-tomcat','jenkins-cli']:


### PR DESCRIPTION
Haskell package manager Cabal uses the HOME environment variable for storing packages. This is not set in the Jenkins server. This change specifies home directory to "/root", which will cause cabal to generate "/root/.cabal" directory and populate with packages and additional information.
