### PR TITLE
Cleanup CamFort dependencies.

### DIFF
--- a/modules/dtg/manifests/jenkins.pp
+++ b/modules/dtg/manifests/jenkins.pp
@@ -22,7 +22,7 @@ class dtg::jenkins {
     'jenkins-crypto-util', 'jenkins-external-job-monitor', 'jenkins-instance-identity', 'jenkins-memory-monitor', 'jenkins-ssh-cli-auth',
     'python3-markdown', 'mercurial', 'python3-urllib3', 'python3-dateutil', 'python3-numpy', 'python3-uncertainties', # For AVO
     'python3-matplotlib', 'python3-scipy', 'python3-cairo', 'python3-cairocffi', 'vnc4server', 'fluxbox', 'python3-dev', 'python3-jsonpickle', # for da-graphing
-    'ghc', 'alex', 'happy', 'libghc-text-dev', 'libghc-comonad-dev', 'libghc-mtl-dev', 'zlibc', 'zlib1g', 'zlib1g-dev', 'cabal-install', # for camfort and camfort-fixtures
+    'ghc', 'cabal-install', # for camfort
     ]
   package { $jenkins_job_packages:
     ensure => installed,
@@ -42,13 +42,6 @@ class dtg::jenkins {
     user        => "tomcat${tomcat_version}",
     environment => "HOME=/usr/share/tomcat${tomcat_version}",
     command     => '/usr/bin/cabal update',
-  } ->
-  exec {'install-cabal-packages':
-    user        => "tomcat${tomcat_version}",
-    environment => "HOME=/usr/share/tomcat${tomcat_version}",
-    # Check if the dependencies are already installed
-    unless      => '/usr/bin/ghc-pkg list | /bin/sed -ze "s/\n//g" | /bin/grep -o fclabels.*generic-deriving.*language-fortran.*matrix.*syz.*uniplate > /dev/null',
-    command     => '/usr/bin/cabal install syz generic-deriving uniplate matrix fclabels language-fortran',
   }
   #packages required by jenkins
   package {['jenkins-tomcat','jenkins-cli']:


### PR DESCRIPTION
Cabal now has a sandboxing functionality that contains dependencies
within the project it is more suitable to run that than install
everything all through puppet.

Also few native packages are no longer needed.
