### PR TITLE
Correct dependencies for CamFort

### DIFF
--- a/modules/dtg/manifests/jenkins.pp
+++ b/modules/dtg/manifests/jenkins.pp
@@ -22,7 +22,7 @@ class dtg::jenkins {
     'jenkins-crypto-util', 'jenkins-external-job-monitor', 'jenkins-instance-identity', 'jenkins-memory-monitor', 'jenkins-ssh-cli-auth',
     'python3-markdown', 'mercurial', 'python3-urllib3', 'python3-dateutil', 'python3-numpy', 'python3-uncertainties', # For AVO
     'python3-matplotlib', 'python3-scipy', 'python3-cairo', 'python3-cairocffi', 'vnc4server', 'fluxbox', 'python3-dev', 'python3-jsonpickle', # for da-graphing
-    'ghc', 'cabal-install', 'liblapack3', # for camfort
+    'ghc', 'cabal-install', 'libgsl0-dev', 'liblapack-dev', 'libatlas-base-dev', # for camfort
     ]
   package { $jenkins_job_packages:
     ensure => installed,


### PR DESCRIPTION
Finally figured out the correct dependencies, it turns out it is from
a dependency of CamFort. If only Haskell had a proper package manager...

Sorry for constant bothering Daniel. Also I know Jenkins is not very happy
with its OS, version but when that sorts itself out, at least I won't bother you
again with this.
