### PR TITLE
removed spaces from backup file mode

### DIFF
--- a/modules/dtg/manifests/backup.pp
+++ b/modules/dtg/manifests/backup.pp
@@ -87,7 +87,7 @@ define dtg::backup::hostsetup($user, $group = $dtg::backup::host::user, $host, $
     ensure => directory,
     owner  => $backupsuser,
     group  => $group,
-    mode   => 'u=rwx, g=rx, o=x',
+    mode   => 'u=rwx,g=rx,o=x',
   }
   cron {"backup ${name}":
     ensure  => present,


### PR DESCRIPTION
I checked using chmod without spaces and it worked fine. Assuming spaces was the problem. 
